### PR TITLE
Add event to register middleware in other plugins

### DIFF
--- a/Impostor.Http/Impostor.Http.csproj
+++ b/Impostor.Http/Impostor.Http.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>0.1</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Impostor.Http/ImpostorHttpPluginStartup.cs
+++ b/Impostor.Http/ImpostorHttpPluginStartup.cs
@@ -12,17 +12,11 @@ using Microsoft.Extensions.Hosting;
 public class ImpostorHttpPluginStartup : IPluginStartup
 {
     /// <summary>
-    /// Type for the OnWebHostConfigure event.
-    /// </summary>
-    /// <param name="app">The application builder for the web host.</param>
-    public delegate void WebHostConfigureHandler(IApplicationBuilder app);
-
-    /// <summary>
     /// Callback for the web host configuration.
     /// </summary>
     ///
     /// Register for this event if you want to insert middleware.
-    public static event WebHostConfigureHandler OnWebHostConfigure = (_) => { };
+    public static event Action<IApplicationBuilder>? OnWebHostConfigure;
 
     /// <inheritdoc/>
     public void ConfigureHost(IHostBuilder host)
@@ -39,7 +33,7 @@ public class ImpostorHttpPluginStartup : IPluginStartup
         {
             builder.Configure(app =>
             {
-                OnWebHostConfigure(app);
+                OnWebHostConfigure?.Invoke(app);
 
                 app.UseRouting();
 

--- a/Impostor.Http/ImpostorHttpPluginStartup.cs
+++ b/Impostor.Http/ImpostorHttpPluginStartup.cs
@@ -11,6 +11,19 @@ using Microsoft.Extensions.Hosting;
  */
 public class ImpostorHttpPluginStartup : IPluginStartup
 {
+    /// <summary>
+    /// Type for the OnWebHostConfigure event.
+    /// </summary>
+    /// <param name="app">The application builder for the web host.</param>
+    public delegate void WebHostConfigureHandler(IApplicationBuilder app);
+
+    /// <summary>
+    /// Callback for the web host configuration.
+    /// </summary>
+    ///
+    /// Register for this event if you want to insert middleware.
+    public static event WebHostConfigureHandler OnWebHostConfigure = (_) => { };
+
     /// <inheritdoc/>
     public void ConfigureHost(IHostBuilder host)
     {
@@ -26,6 +39,8 @@ public class ImpostorHttpPluginStartup : IPluginStartup
         {
             builder.Configure(app =>
             {
+                OnWebHostConfigure(app);
+
                 app.UseRouting();
 
                 app.UseEndpoints(endpoints =>


### PR DESCRIPTION
This adds an event that can be used to register middleware or something else.

Also cleans up a temporary hack that was used for this in ListingManager and bump the version to 0.2.0