### PR TITLE
Reuse configuration from Impostor

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: miniduikboot

--- a/Impostor.Http/GamesController.cs
+++ b/Impostor.Http/GamesController.cs
@@ -2,10 +2,12 @@ namespace Impostor.Http;
 
 using System.Net;
 using System.Text.Json.Serialization;
+using Impostor.Api.Config;
 using Impostor.Api.Games;
 using Impostor.Api.Games.Managers;
 using Impostor.Api.Innersloth;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 /**
  * <summary>
@@ -26,12 +28,13 @@ public class GamesController : ControllerBase
      * </summary>
      * <param name="gameManager">GameManager containing a list of games.</param>
      * <param name="listingManager">ListingManager responsible for filtering.</param>
-     * <param name="config">Prgram configuration containing the public ip address of this server.</param>
+     * <param name="serverConfig">Impostor configuration section containing the public ip address of this server.</param>
      */
-    public GamesController(IGameManager gameManager, ListingManager listingManager, HttpServerConfig config)
+    public GamesController(IGameManager gameManager, ListingManager listingManager, IOptions<ServerConfig> serverConfig)
     {
         this.gameManager = gameManager;
         this.listingManager = listingManager;
+        var config = serverConfig.Value;
         this.hostServer = new(new(IPAddress.Parse(config.PublicIp), config.PublicPort));
     }
 

--- a/Impostor.Http/HttpServerConfig.cs
+++ b/Impostor.Http/HttpServerConfig.cs
@@ -46,20 +46,4 @@ public class HttpServerConfig
      * This field is ignored if SSL is not used.
      */
     public string CertificatePath { get; set; } = string.Empty;
-
-    /**
-     * <summary>
-     * Gets or sets the IP address the HTTP Matchmaking server will listen on.
-     * </summary>
-     * This should be set to the same value as Impostor's PublicIp
-     */
-    public string PublicIp { get; set; } = "127.0.0.1";
-
-    /**
-     * <summary>
-     * Gets or sets the port the game server listens on.
-     * </summary>
-     * This should be set to the same value as Impostor's PublicPort
-     */
-    public ushort PublicPort { get; set; } = 22023;
 }

--- a/Impostor.Http/Impostor.Http.csproj
+++ b/Impostor.Http/Impostor.Http.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Impostor.Api" Version="1.6.0" />
+    <PackageReference Include="Impostor.Api" Version="1.7.2" />
     
     <!-- Code style libraries -->
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.43.0.51858" PrivateAssets="all" />

--- a/Impostor.Http/Impostor.Http.csproj
+++ b/Impostor.Http/Impostor.Http.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Impostor.Http/TokenController.cs
+++ b/Impostor.Http/TokenController.cs
@@ -70,7 +70,7 @@ public class TokenController : ControllerBase
         internal Token(string puid, int clientVersion)
         {
             this.Content = new TokenPayload(puid, clientVersion);
-            this.Hash = "boot_http_was_here";
+            this.Hash = "impostor_http_was_here";
         }
 
         /**

--- a/Impostor.Http/packages.lock.json
+++ b/Impostor.Http/packages.lock.json
@@ -4,12 +4,12 @@
     "net6.0": {
       "Impostor.Api": {
         "type": "Direct",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "UPD7TzP/Zb+RBrgQ5Ljmt3+z3z9ZpvCagBPWAdiRRlRVwPP4Hv+df5xdWHPFSzmV8QMZI+0cHpWvQ7Ls5n6e0g==",
+        "requested": "[1.7.2, )",
+        "resolved": "1.7.2",
+        "contentHash": "9rkOCQ/8XmGnZRE2VDgluysT4d3U9p/G9O2a6hyTZs8sbr4HvCJOL3tiJWOVANk9GeqP9/hAdSIC55S9uunbuA==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "5.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "5.0.0"
+          "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         }
       },
       "SonarAnalyzer.CSharp": {
@@ -29,49 +29,57 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ETjSBHMp3OAZ4HxGQYpwyGsD8Sw5FegQXphi0rpoGMT74S4+I2mm7XJEswwn59XAaKOzC15oDSOWEE8SzDCd6Q==",
+        "resolved": "6.0.0",
+        "contentHash": "qWzV9o+ZRWq+pGm+1dF+R7qTgTYoXvbyowRoBxQJGfqTpqDun2eteerjRQhq5PQ/14S+lqto3Ft4gYaRyl4rdQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "5.0.0"
+          "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ORj7Zh81gC69TyvmcUm9tSzytcy8AVousi+IVRAI8nLieQjOFryRusSFh7+aLk16FN9pQNqJAiMd7BTKINK0kA=="
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "iuZIiZ3mteEb+nsUqpGXKx2cGF+cv6gWPd5jqQI4hzqdiJ6I94ddLjKhQOuRW1lueHwocIw30xbSHGhQj0zjdQ==",
+        "resolved": "6.0.0",
+        "contentHash": "0pd4/fho0gC12rQswaGQxbU34jOS1TPS8lZPpkFCH68ppQjHNHYle9iRuHeev1LhrJ94YPvzcRd8UmIuFk23Qw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "5.0.0"
+          "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "cbUOCePYBl1UhM+N2zmDSUyJ6cODulbtUd9gEzMFIK3RQDtP/gJsE08oLcBSXH3Q1RAQ0ex7OAB3HeTKB9bXpg==",
+        "resolved": "6.0.0",
+        "contentHash": "GcT5l2CYXL6Sa27KCSh0TixsRfADUgth+ojQSD5EkzisZxmGFh7CwzkcYuGwvmXLjr27uWRNrJ2vuuEjMhU05Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "6.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "NxP6ahFcBnnSfwNBi2KH2Oz8Xl5Sm2krjId/jRR3I7teFphwiUoUeZPwTNA21EX+5PtjqmyAvKaOeBXcJjcH/w=="
+        "resolved": "6.0.1",
+        "contentHash": "dzB2Cgg+JmrouhjkcQGzSFjjvpwlq353i8oBQO2GWNjCXSzhbtBRUf28HSauWe7eib3wYOdb3tItdjRwAdwCSg=="
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "cI/VWn9G1fghXrNDagX9nYaaB/nokkZn0HYAawGaELQrl8InSezfe9OnfPZLcJq3esXxygh3hkq2c3qoV3SDyQ=="
+        "resolved": "6.0.0",
+        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
         "resolved": "1.2.0.435",
         "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Adds HTTP matchmaking to [Impostor](https://github.com/Impostor/Impostor)
 
 ## Installation
 
-1. [Install Impostor first](https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md)
+1. [Install Impostor first](https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md). You need version 1.7.2 or newer.
 2. Install [ASP.NET Core Runtime 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) as well
 3. Download [Impostor.Http.dll from the GitHub Releases](https://github.com/Impostor/Impostor.Http/releases) and put it in Impostor's `plugin` folder
 4. In the base Impostor configuration file, add a PluginLoader section to let Impostor find the AspNetCore files:
@@ -19,17 +19,15 @@ Adds HTTP matchmaking to [Impostor](https://github.com/Impostor/Impostor)
 
 Where `x` refers to the minor version of ASP.NET Core 6 you have installed.
 
-5. Finally, create a configuration file for this plugin. You **must** set the PublicIp property, otherwise you will be unable to join your server. See the next section for this.
+5. Finally, if you want to change the default configuration, you need to create a configuration file for this plugin. See the next section for this.
 
 ## Configuration
 
 Configuration is read from the `config_http.json` file or from environment variables prefixed with `IMPOSTOR_HTTP_`. You can copy over [this file](https://github.com/Impostor/Impostor.Http/blob/main/config_http.json) for the default settings. These are the possible keys:
 
-| Key                 | Default     | Description                                                                                                                                                              |
-| ------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **PublicIp**        | `127.0.0.1` | This is the public IP your server is available on. Should be the same as PublicIp in Impostor's `config.json`. You MUST set this key for Impostor.Http to work properly. |
-| **PublicPort**      | `22023`     | Port your Among Us server is listening on, should be the same as PublicPort from your Impostor configuration file.                                                       |
-| **ListenIp**        | `127.0.0.1` | IP address to listen on. Use 127.0.0.1 if using a reverse proxy like nginx (recommended), use 0.0.0.0 if exposed directly (not recommended)                              |
-| **ListenPort**      | 22000       | Port the HTTP matchmaking server is running on.                                                                                                                          |
-| **UseHttps**        | `false`     | Set to true if using encrypted communication to your reverse proxy or if you're exposing this server directly to the internet (not recommended)                          |
-| **CertificatePath** | _not set_   | If UseHttps is enable, set this property to the path of your SSL certificate.                                                                                            |
+| Key                 | Default     | Description                                                                                                                                     |
+| ------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ListenIp**        | `127.0.0.1` | IP address to listen on. Use 127.0.0.1 if using a reverse proxy like nginx (recommended), use 0.0.0.0 if exposed directly (not recommended)     |
+| **ListenPort**      | 22000       | Port the HTTP matchmaking server is running on.                                                                                                 |
+| **UseHttps**        | `false`     | Set to true if using encrypted communication to your reverse proxy or if you're exposing this server directly to the internet (not recommended) |
+| **CertificatePath** | _not set_   | If UseHttps is enable, set this property to the path of your SSL certificate.                                                                   |

--- a/config_http.json
+++ b/config_http.json
@@ -1,7 +1,5 @@
 {
   "HttpServer": {
-    "PublicIp": "127.0.0.1",
-    "PublicPort": 22023,
     "ListenIp": "127.0.0.1",
     "ListenPort": 22000,
     "UseHttps": false,


### PR DESCRIPTION
This bumps the version requirement of Impostor to 1.7.2, but it significantly simplifies the setup required for this plugin