### PR TITLE
Don't check if mapId parameter fits in MapFlags

### DIFF
--- a/Impostor.Http/GamesController.cs
+++ b/Impostor.Http/GamesController.cs
@@ -48,7 +48,7 @@ public class GamesController : ControllerBase
      * <returns>An array of game listings.</returns>
      */
     [HttpGet]
-    public IActionResult Index(MapFlags mapId, GameKeywords lang, int numImpostors)
+    public IActionResult Index(int mapId, GameKeywords lang, int numImpostors)
     {
         IEnumerable<IGame> listings = this.listingManager.FindListings(this.HttpContext, mapId, numImpostors, lang);
         return this.Ok(listings.Select(l => new GameListing(l)));

--- a/Impostor.Http/ListingManager.cs
+++ b/Impostor.Http/ListingManager.cs
@@ -39,7 +39,7 @@ public class ListingManager
      * <param name="maxListings">Maximum amount of games to return.</param>
      * <returns>Listings that match the required criteria.</returns>
      */
-    public IEnumerable<IGame> FindListings(HttpContext ctx, MapFlags map, int impostorCount, GameKeywords language, int maxListings = 10)
+    public IEnumerable<IGame> FindListings(HttpContext ctx, int map, int impostorCount, GameKeywords language, int maxListings = 10)
     {
         int resultCount = 0;
 
@@ -52,7 +52,7 @@ public class ListingManager
             x.PlayerCount < x.Options.MaxPlayers))
         {
             // Check for options.
-            if (!map.HasFlag((MapFlags)(1 << (byte)game.Options.Map)))
+            if ((map & (1 << (int)game.Options.Map)) == 0)
             {
                 continue;
             }


### PR DESCRIPTION
ASP.NET Core checks if mapId is permissible according to the MapFlags enum.

MapFlags hasn't been updated since Airship, and I don't want to cut an Impostor release right now just to fix that. It would also cause issues with mods that define additional map id's. So switch away from MapFlags completely.