### PR TITLE
Resolve public ip

### DIFF
--- a/Impostor.Http/GamesController.cs
+++ b/Impostor.Http/GamesController.cs
@@ -35,7 +35,7 @@ public class GamesController : ControllerBase
         this.gameManager = gameManager;
         this.listingManager = listingManager;
         var config = serverConfig.Value;
-        this.hostServer = new(new(IPAddress.Parse(config.PublicIp), config.PublicPort));
+        this.hostServer = new(new(IPAddress.Parse(config.ResolvePublicIp()), config.PublicPort));
     }
 
     /**


### PR DESCRIPTION
Impostor already allowed using an fqdn as your public ip, but Impostor.Http didn't. Resolve the public ip in the same way as Impostor for feature parity.

Closes #4