### PR TITLE
Feature/net7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.x
+          dotnet-version: 7.x
 
       - name: Install dependencies
         run: dotnet restore --locked-mode
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: Impostor.Http.dll
-          path: Impostor.Http/bin/Release/net6.0/Impostor.Http.dll
+          path: Impostor.Http/bin/Release/net7.0/Impostor.Http.dll
 
       - uses: actions/upload-artifact@v2
         with:
@@ -39,4 +39,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
-          files: Impostor.Http/bin/Release/net6.0/Impostor.Http.dll
+          files: Impostor.Http/bin/Release/net7.0/Impostor.Http.dll

--- a/Impostor.Http/Impostor.Http.csproj
+++ b/Impostor.Http/Impostor.Http.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Impostor.Http/Impostor.Http.csproj
+++ b/Impostor.Http/Impostor.Http.csproj
@@ -2,8 +2,8 @@
   
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <TargetFramework>net7.0</TargetFramework>
+    <VersionPrefix>0.3.1</VersionPrefix>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Impostor.Http/Impostor.Http.csproj
+++ b/Impostor.Http/Impostor.Http.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Impostor.Api" Version="1.7.2" />
+    <PackageReference Include="Impostor.Api" Version="1.8.0" />
     
     <!-- Code style libraries -->
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.43.0.51858" PrivateAssets="all" />

--- a/Impostor.Http/ImpostorHttpPluginStartup.cs
+++ b/Impostor.Http/ImpostorHttpPluginStartup.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
 namespace Impostor.Http;
 
 using System.Net;
@@ -47,6 +49,8 @@ public class ImpostorHttpPluginStartup : IPluginStartup
             {
                 serverOptions.Listen(IPAddress.Parse(config.ListenIp), config.ListenPort, listenOptions =>
                 {
+                    listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+
                     if (config.UseHttps)
                     {
                         listenOptions.UseHttps(config.CertificatePath);

--- a/Impostor.Http/packages.lock.json
+++ b/Impostor.Http/packages.lock.json
@@ -4,12 +4,13 @@
     "net7.0": {
       "Impostor.Api": {
         "type": "Direct",
-        "requested": "[1.7.2, )",
-        "resolved": "1.7.2",
-        "contentHash": "9rkOCQ/8XmGnZRE2VDgluysT4d3U9p/G9O2a6hyTZs8sbr4HvCJOL3tiJWOVANk9GeqP9/hAdSIC55S9uunbuA==",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "gw1RW4XTW099DOAZi2uDa8TroRlpQbxOTKtU/PId8slHyRZfkurx2Vxy5OjIqC5iqF6OAFoicDeCXQP4TlSkrg==",
         "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
+          "Impostor.Hazel.Abstractions": "1.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         }
       },
       "SonarAnalyzer.CSharp": {
@@ -27,59 +28,56 @@
           "StyleCop.Analyzers.Unstable": "1.2.0.435"
         }
       },
+      "Impostor.Hazel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "x56AEsY5fKU2Z5O7ZrzEqKfr62kq/C05Aevcciwz5yMfOQlpwuFI1awgNGJsoe+bcx+XnFc3+l+eadtY72aZsg=="
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "qWzV9o+ZRWq+pGm+1dF+R7qTgTYoXvbyowRoBxQJGfqTpqDun2eteerjRQhq5PQ/14S+lqto3Ft4gYaRyl4rdQ==",
+        "resolved": "7.0.0",
+        "contentHash": "f34u2eaqIjNO9YLHBz8rozVZ+TcFiFs0F3r7nUJd7FRkVSxk8u4OpoK226mi49MwexHOR2ibP9MFvRUaLilcQQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+        "resolved": "7.0.0",
+        "contentHash": "h3j/QfmFN4S0w4C2A6X7arXij/M/OVw3uQHSOFxnND4DyAzO1F9eMX7Eti7lU/OkSthEE0WzRsfT/Dmx86jzCw=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "0pd4/fho0gC12rQswaGQxbU34jOS1TPS8lZPpkFCH68ppQjHNHYle9iRuHeev1LhrJ94YPvzcRd8UmIuFk23Qw==",
+        "resolved": "7.0.0",
+        "contentHash": "NyawiW9ZT/liQb34k9YqBSNPLuuPkrjMgQZ24Y/xXX1RoiBkLUdPMaQTmxhZ5TYu8ZKZ9qayzil75JX95vGQUg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "GcT5l2CYXL6Sa27KCSh0TixsRfADUgth+ojQSD5EkzisZxmGFh7CwzkcYuGwvmXLjr27uWRNrJ2vuuEjMhU05Q==",
+        "resolved": "7.0.0",
+        "contentHash": "43n9Je09z0p/7ViPxfRqs5BUItRLNVh5b6JH40F2Agkh2NBsY/jpNYTtbCcxrHCsA3oRmbR6RJBzUutB4VZvNQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "6.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "7.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "dzB2Cgg+JmrouhjkcQGzSFjjvpwlq353i8oBQO2GWNjCXSzhbtBRUf28HSauWe7eib3wYOdb3tItdjRwAdwCSg=="
+        "resolved": "7.0.0",
+        "contentHash": "kmn78+LPVMOWeITUjIlfxUPDsI0R6G0RkeAMBmQxAJ7vBJn4q2dTva7pWi65ceN5vPGjJ9q/Uae2WKgvfktJAw=="
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "7.0.0",
+        "contentHash": "um1KU5kxcRp3CNuI8o/GrZtD4AIOXDk+RLsytjZ9QPok3ttLUelLKpilVPuaFT3TFjOhSibUAso0odbOaCDj3Q=="
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
         "resolved": "1.2.0.435",
         "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       }
     }
   }

--- a/Impostor.Http/packages.lock.json
+++ b/Impostor.Http/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net7.0": {
       "Impostor.Api": {
         "type": "Direct",
         "requested": "[1.7.2, )",

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Adds HTTP matchmaking to [Impostor](https://github.com/Impostor/Impostor)
 
 ## Installation
 
-1. [Install Impostor first](https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md). You need version 1.7.2 or newer.
-2. Install [ASP.NET Core Runtime 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) as well
+1. [Install Impostor first](https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md). You need version 1.8.0 or newer.
+2. Install [ASP.NET Core Runtime 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) as well
 3. Download [Impostor.Http.dll from the GitHub Releases](https://github.com/Impostor/Impostor.Http/releases) and put it in Impostor's `plugin` folder
 4. In the base Impostor configuration file, add a PluginLoader section to let Impostor find the AspNetCore files:
 
 ```json
 {
   "PluginLoader": {
-    "LibraryPaths": ["/usr/share/dotnet/shared/Microsoft.AspNetCore.App/6.0.x"]
+    "LibraryPaths": ["/usr/share/dotnet/shared/Microsoft.AspNetCore.App/7.0.x"]
   }
 }
 ```
 
-Where `x` refers to the minor version of ASP.NET Core 6 you have installed.
+Where `x` refers to the minor version of ASP.NET Core 7 you have installed.
 
 5. Finally, if you want to change the default configuration, you need to create a configuration file for this plugin. See the next section for this.
 


### PR DESCRIPTION
This updates Impostor.Http to .NET 7 as well. This is needed because Impostor.Http is tied to ASP.Net Core. Loading Impostor.Http 0.3.0 into Impostor 1.8 seems to work until you try to get it to serve a request, as which point it will throw an error.