### PR TITLE
Feature/better defaults and readme

### DIFF
--- a/Impostor.Http/HttpServerConfig.cs
+++ b/Impostor.Http/HttpServerConfig.cs
@@ -21,7 +21,7 @@ public class HttpServerConfig
      * Use "127.0.0.1" if you are running behind a reverse proxy or just testing locally.
      * Use "0.0.0.0" if you are directly exposing this server to the internet (not recommended).
      */
-    public string ListenIp { get; set; } = "127.0.0.1";
+    public string ListenIp { get; set; } = "0.0.0.0";
 
     /**
      * <summary>
@@ -29,7 +29,7 @@ public class HttpServerConfig
      * </summary>
      * For port forwarding purposes, this is a TCP port.
      */
-    public ushort ListenPort { get; set; } = 22000;
+    public ushort ListenPort { get; set; } = 22023;
 
     /**
      * <summary>

--- a/Impostor.Http/HttpServerConfig.cs
+++ b/Impostor.Http/HttpServerConfig.cs
@@ -21,7 +21,7 @@ public class HttpServerConfig
      * Use "127.0.0.1" if you are running behind a reverse proxy or just testing locally.
      * Use "0.0.0.0" if you are directly exposing this server to the internet (not recommended).
      */
-    public string ListenIp { get; set; } = "0.0.0.0";
+    public string ListenIp { get; set; } = "127.0.0.1";
 
     /**
      * <summary>

--- a/Impostor.Http/Impostor.Http.csproj
+++ b/Impostor.Http/Impostor.Http.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Adds HTTP matchmaking to [Impostor](https://github.com/Impostor/Impostor)
 
 Configuration is read from the `config_http.json` file or from environment variables prefixed with `IMPOSTOR_HTTP_`. You can copy over [this file](https://github.com/Impostor/Impostor.Http/blob/main/config_http.json) for the default settings. These are the possible keys:
 
-| Key                 | Default   | Description                                                                                                                                     |
-| ------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ListenIp**        | `0.0.0.0` | IP address to listen on. Use 127.0.0.1 if using a reverse proxy like nginx (recommended), use 0.0.0.0 if exposed directly (not recommended)     |
-| **ListenPort**      | 22023     | Port the HTTP matchmaking server is running on.                                                                                                 |
-| **UseHttps**        | `false`   | Set to true if using encrypted communication to your reverse proxy or if you're exposing this server directly to the internet (not recommended) |
-| **CertificatePath** | _not set_ | If UseHttps is enable, set this property to the path of your SSL certificate in PFX format.                                                     |
+| Key                 | Default     | Description                                                                                                                                     |
+| ------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ListenIp**        | `127.0.0.1` | IP address to listen on. Use 127.0.0.1 if using a reverse proxy like nginx (recommended), use 0.0.0.0 if exposed directly (not recommended)     |
+| **ListenPort**      | 22023       | Port the HTTP matchmaking server is running on.                                                                                                 |
+| **UseHttps**        | `false`     | Set to true if using encrypted communication to your reverse proxy or if you're exposing this server directly to the internet (not recommended) |
+| **CertificatePath** | _not set_   | If UseHttps is enable, set this property to the path of your SSL certificate in PFX format.                                                     |
 
 ## HTTPS configuration
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ server {
     ssl_stapling_verify on;
 
     location / {
-        proxy_pass http://localhost:22000;
+        proxy_pass http://localhost:22023;
         proxy_pass_header Server;
         proxy_buffering off;
         proxy_redirect off;

--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ The reverse proxy can terminate HTTPS for you. To configure this:
 4. Configure your reverse proxy. For nginx, we have a sample config available. For the other servers, please refer to your server's documentation.
 
 <details>
+
 <summary>Nginx server configuration</summary>
-Replace YOUR_SERVER_NAME_HERE with the hostname of your server
+
+Replace YOUR_SERVER_NAME_HERE with the hostname of your server:
+
 ```nginx
 server {
     listen 443 ssl http2;
@@ -78,8 +81,8 @@ server {
     }
 
 }
-
 ```
+
 </details>
 
 ### 2. Use the Https feature of Impostor.Http
@@ -91,5 +94,3 @@ We don't recommend using this option for a couple reasons: it is not very flexib
 3. Use Let's Encrypt or a similar service to get an SSL certificate. We recommend [Certbot](https://certbot.eff.org/). Self-signed certificates are not enough.
 4. Convert your certificate to PFX format, for example using OpenSSL: `openssl pkcs12 -export -out certificate_fullchain.pfx -inkey privkey.pem -in fullchain.pem`.
 5. Set CertificatePath to the path to this `certificate_fullchain.pfx` file.
-
-```

--- a/README.md
+++ b/README.md
@@ -4,30 +4,92 @@ Adds HTTP matchmaking to [Impostor](https://github.com/Impostor/Impostor)
 
 ## Installation
 
-1. [Install Impostor first](https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md). You need version 1.8.0 or newer.
+1. [Install Impostor first](https://github.com/Impostor/Impostor/blob/master/docs/Running-the-server.md). You need version 1.8.1 or newer.
 2. Install [ASP.NET Core Runtime 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) as well
 3. Download [Impostor.Http.dll from the GitHub Releases](https://github.com/Impostor/Impostor.Http/releases) and put it in Impostor's `plugin` folder
-4. In the base Impostor configuration file, add a PluginLoader section to let Impostor find the AspNetCore files:
-
-```json
-{
-  "PluginLoader": {
-    "LibraryPaths": ["/usr/share/dotnet/shared/Microsoft.AspNetCore.App/7.0.x"]
-  }
-}
-```
-
-Where `x` refers to the minor version of ASP.NET Core 7 you have installed.
-
-5. Finally, if you want to change the default configuration, you need to create a configuration file for this plugin. See the next section for this.
+4. Finally, if you want to change the default configuration, you need to create a configuration file for this plugin. See the next section for this.
 
 ## Configuration
 
 Configuration is read from the `config_http.json` file or from environment variables prefixed with `IMPOSTOR_HTTP_`. You can copy over [this file](https://github.com/Impostor/Impostor.Http/blob/main/config_http.json) for the default settings. These are the possible keys:
 
-| Key                 | Default     | Description                                                                                                                                     |
-| ------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ListenIp**        | `127.0.0.1` | IP address to listen on. Use 127.0.0.1 if using a reverse proxy like nginx (recommended), use 0.0.0.0 if exposed directly (not recommended)     |
-| **ListenPort**      | 22000       | Port the HTTP matchmaking server is running on.                                                                                                 |
-| **UseHttps**        | `false`     | Set to true if using encrypted communication to your reverse proxy or if you're exposing this server directly to the internet (not recommended) |
-| **CertificatePath** | _not set_   | If UseHttps is enable, set this property to the path of your SSL certificate.                                                                   |
+| Key                 | Default   | Description                                                                                                                                     |
+| ------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ListenIp**        | `0.0.0.0` | IP address to listen on. Use 127.0.0.1 if using a reverse proxy like nginx (recommended), use 0.0.0.0 if exposed directly (not recommended)     |
+| **ListenPort**      | 22023     | Port the HTTP matchmaking server is running on.                                                                                                 |
+| **UseHttps**        | `false`   | Set to true if using encrypted communication to your reverse proxy or if you're exposing this server directly to the internet (not recommended) |
+| **CertificatePath** | _not set_ | If UseHttps is enable, set this property to the path of your SSL certificate in PFX format.                                                     |
+
+## HTTPS configuration
+
+To enable support for Android/iOS devices, you need to enable HTTPS. If you don't need to support phones, you can skip this section. Enabling HTTPS can be done in one of two ways:
+
+### 1. Use a Reverse Proxy like nginx, apache or caddy
+
+The reverse proxy can terminate HTTPS for you. To configure this:
+
+1. Set ListenIp to `127.0.0.1` so that Impostor.Http can only be reached using the Reverse Proxy.
+2. Set UseHttps to `false`.
+3. Use Let's Encrypt or a similar service to get an SSL certificate. We recommend [Certbot](https://certbot.eff.org/). Self-signed certificates are not enough.
+4. Configure your reverse proxy. For nginx, we have a sample config available. For the other servers, please refer to your server's documentation.
+
+<details>
+<summary>Nginx server configuration</summary>
+Replace YOUR_SERVER_NAME_HERE with the hostname of your server
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name YOUR_SERVER_NAME_HERE;
+
+    ssl_certificate /etc/letsencrypt/live/YOUR_SERVER_NAME_HERE/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/YOUR_SERVER_NAME_HERE/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/YOUR_SERVER_NAME_HERE/fullchain.pem;
+
+    include /etc/nginx/ssl_ciphers; # https://ssl-config.mozilla.org/#server=nginx&version=1.16.1&config=intermediate&openssl=1.1.1d&guideline=5.4
+
+    # generated 2023-03-19, Mozilla Guideline v5.6, nginx 1.17.7, OpenSSL 1.1.1d, intermediate configuration, no HSTS
+    # https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&hsts=false&guideline=5.6
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+    ssl_session_tickets off;
+
+    # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam
+    ssl_dhparam /path/to/dhparam;
+
+    # intermediate configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # OCSP stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    location / {
+        proxy_pass http://localhost:22000;
+        proxy_pass_header Server;
+        proxy_buffering off;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;  # http://wiki.nginx.org/HttpProxyModule
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;  # recommended with keepalive connections
+    }
+
+}
+
+```
+</details>
+
+### 2. Use the Https feature of Impostor.Http
+
+We don't recommend using this option for a couple reasons: it is not very flexible as it requires PFX certificates and it needs to be restarted to reload the certificate. But in case you really don't want to use a reverse proxy, here's how to do it:
+
+1. Set ListenIp to `0.0.0.0` so that your server can be reached externally.
+2. Set UseHttps to `true`.
+3. Use Let's Encrypt or a similar service to get an SSL certificate. We recommend [Certbot](https://certbot.eff.org/). Self-signed certificates are not enough.
+4. Convert your certificate to PFX format, for example using OpenSSL: `openssl pkcs12 -export -out certificate_fullchain.pfx -inkey privkey.pem -in fullchain.pem`.
+5. Set CertificatePath to the path to this `certificate_fullchain.pfx` file.
+
+```

--- a/config_http.json
+++ b/config_http.json
@@ -1,6 +1,6 @@
 {
   "HttpServer": {
-    "ListenIp": "0.0.0.0",
+    "ListenIp": "127.0.0.1",
     "ListenPort": 22023,
     "UseHttps": false,
     "CertificatePath": ""

--- a/config_http.json
+++ b/config_http.json
@@ -1,7 +1,7 @@
 {
   "HttpServer": {
-    "ListenIp": "127.0.0.1",
-    "ListenPort": 22000,
+    "ListenIp": "0.0.0.0",
+    "ListenPort": 22023,
     "UseHttps": false,
     "CertificatePath": ""
   }


### PR DESCRIPTION
Half a year later it's time to update the readme to fix some regularly occurring issues:

1. Impostor 1.8.1 improved the install process by autoloading Asp.net CORE.
2. People keep messing up the port configuration on the website.
3. Our portforwarding instructions sucked because they used two ports. So now there is one port to rule them all and in the protocols bind them.
4. People don't want to install a reverse proxy because It's Hard so make it easier for them not to by setting the ListenIp to 0.

- [ ] update the website once this PR is merged and a release is tagged